### PR TITLE
Selvbetjent samtykke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
   deploy-to-dev:
     name: Deploy to dev
     needs: build-and-publish
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/chainguard-image'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/SelvbetjentSamtykke'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -50,9 +50,6 @@ spec:
           cluster: {{ gcp-cluster }}
     outbound:
       rules:
-        - application: logging
-          namespace: nais-system
-          cluster: {{ gcp-cluster }}
         - application: pam-personoppslag
           namespace: teampam
           cluster: {{ gcp-cluster }}

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -48,6 +48,14 @@ spec:
         - application: pam-dir-api
           namespace: teampam
           cluster: {{ gcp-cluster }}
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
+          cluster: {{ gcp-cluster }}
+        - application: pam-personoppslag
+          namespace: teampam
+          cluster: {{ gcp-cluster }}
   kafka:
     pool: {{ kafka-pool }}
   env:

--- a/src/main/kotlin/ForespørselController.kt
+++ b/src/main/kotlin/ForespørselController.kt
@@ -28,11 +28,7 @@ class ForespørselController(
     private val personoppslagKlient: PersonOppslagKlient,
     private val autorisasjon: Autorisasjon
 ) {
-    companion object {
-        private val LOG = LoggerFactory.getLogger(ForespørselController::class.java)
-        // TODO team logs er ikke satt opp for denne applikasjonen
-        private val teamLogsMarker = MarkerFactory.getMarker("TEAM_LOGS")
-    }
+
     val samtykkTilDelingAvCV: (Context) -> Unit = { ctx ->
         var navKontor: String? = null
         try {
@@ -42,25 +38,20 @@ class ForespørselController(
             ctx.status(400)
             null
         }?.let { stillingsId ->
-            LOG.info("Bruker fra $navKontor samtykker til deling av CV for stilling $stillingsId")
             val fnr = tokenHandler.hentFnr(ctx)
-            val personInfo = personoppslagKlient.personoppslag(fnr)!!
-            val eksisterendeForespørsel = repository.hentForespørsler(stillingsId.toUUID())
-                .filter { it.aktørId == personInfo.aktorId }
-                .firstOrNull()
-
-            if (eksisterendeForespørsel != null) {
-                // TODO Her må vi vurdere litt hva vi skal gjøre. Skal vi overskrive svaret uansett, eller skal vi feile litt avhengig av hva tilstanden er?
-                // Dette må diskuteres med toi
-                LOG.info("Bruker fra $navKontor har allerede samtykket til deling av CV for stilling $stillingsId – eller forespørsel om deleing er sendt av markedskontakt: ${eksisterendeForespørsel.forespørselId}")
-
-                repository.oppdaterMedRespons(eksisterendeForespørsel.forespørselId, Tilstand.HAR_SVART, Svar(true,
-                    LocalDateTime.now(), Ident(personInfo.aktorId!!, IdentType.AKTOR_ID)), null)
-            } else {
-                repository.opprettSelvbetjentForespørselMedSvarJa(stillingsId.toUUID(), personInfo.aktorId!!, navKontor ?: "", ctx.hentCallId())
+            when (val resultat = registrerSelvbetjentSamtykke(navKontor ?: "", stillingsId, fnr, ctx.hentCallId())) {
+                is Feil -> {
+                    loggFeilMedStilling(
+                        resultat.feilmelding,
+                        stillingsId,
+                        resultat.loggLevel
+                    )
+                    ctx.status(resultat.httpResponsStatusKode).json(resultat.feilmelding)
+                }
+                is Ok -> {
+                    ctx.status(200)
+                }
             }
-
-            ctx.status(200)
         }
     }
 
@@ -218,6 +209,27 @@ class ForespørselController(
         repository.hentForespørsler(stillingsId.toUUID())
             .map { it.tilOutboundDto() }
             .groupBy { it.aktørId }
+
+    private fun registrerSelvbetjentSamtykke(navKontor: String, stillingsId: String, fnr: String, callId: String): Resultat {
+        log.info("Bruker fra $navKontor samtykker til deling av CV for stilling $stillingsId")
+        val personInfo = personoppslagKlient.personoppslag(fnr)!!
+        val eksisterendeForespørsel = repository.hentForespørsler(stillingsId.toUUID())
+            .filter { it.aktørId == personInfo.aktorId }
+            .firstOrNull()
+
+        if (eksisterendeForespørsel != null) {
+            // TODO Her må vi vurdere litt hva vi skal gjøre. Skal vi overskrive svaret uansett, eller skal vi feile litt avhengig av hva tilstanden er?
+            // Dette må diskuteres med toi
+            log.info("Bruker fra $navKontor har allerede samtykket til deling av CV for stilling $stillingsId – eller forespørsel om deleing er sendt av markedskontakt: ${eksisterendeForespørsel.forespørselId}")
+
+            repository.oppdaterMedRespons(eksisterendeForespørsel.forespørselId, Tilstand.HAR_SVART, Svar(true,
+                LocalDateTime.now(), Ident(personInfo.aktorId!!, IdentType.AKTOR_ID)), null)
+        } else {
+            repository.opprettSelvbetjentForespørselMedSvarJa(stillingsId.toUUID(), personInfo.aktorId!!, navKontor, callId)
+        }
+
+        return Ok
+    }
 
     private fun loggFeilMedStilling(feilmelding: String, stillingsId: String, loggLevel: Level) {
         val msg = feilmelding.dropLastWhile { it == '.' || it == ':' } + ". StillingsId: $stillingsId"

--- a/src/main/kotlin/ForespørselController.kt
+++ b/src/main/kotlin/ForespørselController.kt
@@ -3,6 +3,8 @@ import auth.TokenHandler
 import auth.TokenHandler.Rolle.*
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import io.javalin.http.Context
+import org.slf4j.LoggerFactory
+import org.slf4j.MarkerFactory
 import org.slf4j.event.Level
 import org.slf4j.event.Level.*
 import stilling.Stilling
@@ -26,6 +28,11 @@ class ForespørselController(
     private val personoppslagKlient: PersonOppslagKlient,
     private val autorisasjon: Autorisasjon
 ) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ForespørselController::class.java)
+        // TODO team logs er ikke satt opp for denne applikasjonen
+        private val teamLogsMarker = MarkerFactory.getMarker("TEAM_LOGS")
+    }
     val samtykkTilDelingAvCV: (Context) -> Unit = { ctx ->
         var navKontor: String? = null
         try {
@@ -35,6 +42,7 @@ class ForespørselController(
             ctx.status(400)
             null
         }?.let { stillingsId ->
+            LOG.info("Bruker fra $navKontor samtykker til deling av CV for stilling $stillingsId")
             val fnr = tokenHandler.hentFnr(ctx)
             val personInfo = personoppslagKlient.personoppslag(fnr)!!
             val eksisterendeForespørsel = repository.hentForespørsler(stillingsId.toUUID())
@@ -44,6 +52,8 @@ class ForespørselController(
             if (eksisterendeForespørsel != null) {
                 // TODO Her må vi vurdere litt hva vi skal gjøre. Skal vi overskrive svaret uansett, eller skal vi feile litt avhengig av hva tilstanden er?
                 // Dette må diskuteres med toi
+                LOG.info("Bruker fra $navKontor har allerede samtykket til deling av CV for stilling $stillingsId – eller forespørsel om deleing er sendt av markedskontakt: ${eksisterendeForespørsel.forespørselId}")
+
                 repository.oppdaterMedRespons(eksisterendeForespørsel.forespørselId, Tilstand.HAR_SVART, Svar(true,
                     LocalDateTime.now(), Ident(personInfo.aktorId!!, IdentType.AKTOR_ID)), null)
             } else {

--- a/src/test/kotlin/LokalApp.kt
+++ b/src/test/kotlin/LokalApp.kt
@@ -84,6 +84,8 @@ fun startLokalApp(
     )
     val autorisasjon = Autorisasjon(kandidatsokApiKlient)
 
+    // Hvis man faktisk skal få personoppslagklienten til å fungere så må man lage seg en fornuftig teststrategi her
+    // Personoppslagklienten brukes i tjenesten(e) for selvbetjent samtykke
     val personoppslagKlient = PersonOppslagKlient(System.getenv("PERSONOPPSLAG_BASE_URL") ?: "http://localhost:18300/",
         { "token" })
     val forespørselController =

--- a/src/test/kotlin/LokalApp.kt
+++ b/src/test/kotlin/LokalApp.kt
@@ -15,12 +15,14 @@ import no.nav.veilarbaktivitet.avro.DelingAvCvRespons
 import no.nav.veilarbaktivitet.stilling_fra_nav.deling_av_cv.ForesporselOmDelingAvCv
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.producer.Producer
+import org.mockito.Mockito.mock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import sendforespørsel.ForespørselService
 import sendforespørsel.UsendtScheduler
 import setup.*
 import stilling.Stilling
+import utils.PersonOppslagKlient
 import java.net.URL
 import java.util.*
 
@@ -82,8 +84,10 @@ fun startLokalApp(
     )
     val autorisasjon = Autorisasjon(kandidatsokApiKlient)
 
+    val personoppslagKlient = PersonOppslagKlient(System.getenv("PERSONOPPSLAG_BASE_URL") ?: "http://localhost:18300/",
+        { "token" })
     val forespørselController =
-        ForespørselController(repository, tokenHandler, usendtScheduler::kjørEnGang, hentStilling, autorisasjon)
+        ForespørselController(repository, tokenHandler, usendtScheduler::kjørEnGang, hentStilling, personoppslagKlient, autorisasjon)
     val svarstatistikkController = SvarstatistikkController(repository)
 
 


### PR DESCRIPTION
Lar bruker selv registrere et samtykke til deling av cv med arbeidsgiver for oppgitt stilling (initiert fra pam-dir-api)
Det er noen utestående spørsmål som Toi bør ta stilling til:

- Hva skal skje hvis markedskontakt allerede har sendt ut en forespørsel om deling av cv?
- Hva hvis bruker har registrert seg allerede (uavhengig av status ja/nei til deling)
- Hvordan skal trekking av samtykke foregå: ved å ta kontakt med veileder, eller skal bruker kunne gjøre det selv?
